### PR TITLE
Extend ellipsoidPhantom

### DIFF
--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -55,9 +55,6 @@ function ellipsoidPhantom(N::NTuple{D,Int}; rng::AbstractRNG = GLOBAL_RNG,
     shift = N .* ntuple(_ -> 0.6*(rand(rng)-0.5), D) 
     value = scaleValue.(rand(rng, 1), minValue)#.^2
     kernelWidth = ntuple(_ -> rand(rng)*N[1] / 20, D)
-    if shift > radius
-      shift = radius
-    end
     P = singleEllipsoid(N, radius, shift, rotAngles)
     P = imfilter(P, Kernel.gaussian(kernelWidth))
     if allowOcclusion

--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -1,15 +1,12 @@
+ellipsoidFunction(::NTuple{D, Int}) where D = throw(ArgumentError("Ellipsoid phantoms are currently not implemented for $D dimensions."))
+ellipsoidFunction(::NTuple{2, Int}) = ellipse
+ellipsoidFunction(::NTuple{3, Int}) = ellipsoid
 
 # Based in ImagePhantoms.jl
 function singleEllipsoid(N::NTuple{D,Int}, radius, shift, rotAngles) where D
   ranges = ntuple(d-> 1:N[d], D)
-  if D == 2
-    ellipsoidFct = ellipse
-  elseif D == 3
-    ellipsoidFct = ellipsoid
-  else
-    throw(ArgumentError("N=$N with $D dimensions is currently not supported."))
-  end
-  ob = ellipsoidFct(shift .+ (N.÷2), radius, rotAngles, 1.0f0)
+  objectFunction = ellipsoidFunction(N)
+  ob = objectFunction(shift .+ (N.÷2), radius, rotAngles, 1.0f0)
   img = phantom(ranges..., [ob], 2)
   return img
 end

--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -8,22 +8,52 @@ function singleEllipsoid(N::NTuple{D,Int}, radius, shift, rotAngles) where D
   return img
 end
 
+"""
+  ellipsoidPhantom(
+    N::NTuple{D,Int}; 
+    rng::AbstractRNG = GLOBAL_RNG,
+    numObjects::Int = rand(rng, 5:10),
+    minRadius::Real=1.0,
+    minValue::Real=0.1,
+    allowOcclusion::Bool=false
+  )
+
+- `N`: size of the phantom image
+- `rng`: random number generator
+- `numObjects`: number of ellipses to generate
+- `minRadius`: minimal radius in pixel
+- `minValue`: minimal value of a single ellipse
+- `allowOcclusion`: if `true` ellipse overshadows smaller values at its location, i.e., 
+      new ellipses are not simply added to the exisiting object, instead the maximum is selected
+
+"""
 function ellipsoidPhantom(N::NTuple{D,Int}; rng::AbstractRNG = GLOBAL_RNG,
-                                            numObjects::Int = rand(rng, 5:10)) where D
+                          numObjects::Int = rand(rng, 5:10), minRadius::Real=1.0,
+                          minValue::Real=0.1, allowOcclusion::Bool=false) where D
   img = zeros(N)
-  @info numObjects
+  @debug numObjects
+  # scale values from interval [0,1] to [a,1]
+  function scaleValue(x::T, a::Real) where {T <: Real}
+    @assert a >= zero(T) && a < one(T) "scaling factor a must lie in the interval [0,1] but is $a"
+    return a + (x*(1-a))
+  end
   for m=1:numObjects
-    rotAngles = ntuple(_ -> 2π*rand(rng), D)
-    radius = N .* ntuple(_ -> 0.3*rand(rng), D)
+    # in 2D there is just one rotational degree of freedom
+    rotAngles = ntuple(_ -> 2π*rand(rng), D == 2 ? 1 : D)
+    radius = N .* scaleValue.(ntuple(_ -> 0.3*rand(rng), D), minRadius./N)
     shift = N .* ntuple(_ -> 0.6*(rand(rng)-0.5), D) 
-    value = (rand(rng, 1))#.^2
+    value = scaleValue.(rand(rng, 1), minValue)#.^2
     kernelWidth = ntuple(_ -> rand(rng)*N[1] / 20, D)
     if shift > radius
       shift = radius
     end
     P = singleEllipsoid(N, radius, shift, rotAngles)
     P = imfilter(P, Kernel.gaussian(kernelWidth))
+    if allowOcclusion
+      img = max.(img, value.*P)
+    else
     img += value.*P
+    end
   end
   return img
 end

--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -15,6 +15,17 @@ function singleEllipsoid(N::NTuple{D,Int}, radius, shift, rotAngles) where D
 end
 
 """
+    scaleValue(x, a, b)
+Scale a value `x` that is assumed to lie in the interval [0,1] 
+to the interval [a,b] for given values a and b.
+"""
+function scaleValue(x::T, a::Real, b::Real=one(T)) where {T <: Real}
+  @assert a >= zero(T) && a < one(T) "scaling factor a must lie in the interval [0,1) but is $a"
+  @assert x >= zero(T) && x <= one(T) "value x is assumed to lie in the interval [0,1] but is $x"
+  return a + (x*(b-a))
+end
+
+"""
   ellipsoidPhantom(
     N::NTuple{D,Int}; 
     rng::AbstractRNG = GLOBAL_RNG,
@@ -31,18 +42,12 @@ end
 - `minValue`: minimal value of a single ellipse
 - `allowOcclusion`: if `true` ellipse overshadows smaller values at its location, i.e., 
       new ellipses are not simply added to the exisiting object, instead the maximum is selected
-
 """
 function ellipsoidPhantom(N::NTuple{D,Int}; rng::AbstractRNG = GLOBAL_RNG,
                           numObjects::Int = rand(rng, 5:10), minRadius::Real=1.0,
                           minValue::Real=0.1, allowOcclusion::Bool=false) where D
   img = zeros(N)
   @debug numObjects
-  # scale values from interval [0,1] to [a,1]
-  function scaleValue(x::T, a::Real) where {T <: Real}
-    @assert a >= zero(T) && a < one(T) "scaling factor a must lie in the interval [0,1] but is $a"
-    return a + (x*(1-a))
-  end
   for m=1:numObjects
     # in 2D there is just one rotational degree of freedom
     rotAngles = ntuple(_ -> 2π*rand(rng), D == 2 ? 1 : D)

--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -1,9 +1,15 @@
 
 # Based in ImagePhantoms.jl
 function singleEllipsoid(N::NTuple{D,Int}, radius, shift, rotAngles) where D
-
   ranges = ntuple(d-> 1:N[d], D)
-  ob = ellipsoid(shift .+ (N.÷2), radius, rotAngles, 1.0f0)
+  if D == 2
+    ellipsoidFct = ellipse
+  elseif D == 3
+    ellipsoidFct = ellipsoid
+  else
+    throw(ArgumentError("N=$N with $D dimensions is currently not supported."))
+  end
+  ob = ellipsoidFct(shift .+ (N.÷2), radius, rotAngles, 1.0f0)
   img = phantom(ranges..., [ob], 2)
   return img
 end
@@ -52,7 +58,7 @@ function ellipsoidPhantom(N::NTuple{D,Int}; rng::AbstractRNG = GLOBAL_RNG,
     if allowOcclusion
       img = max.(img, value.*P)
     else
-    img += value.*P
+      img += value.*P
     end
   end
   return img

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,5 +20,8 @@ using Test
   im2 = ellipsoidPhantom(N; rng=StableRNG(1))
   @test im ≈ im2
 
+  im = ellipsoidPhantom(N; allowOcclusion=true)
+  @test maximum(im) <= 1
+
   #isosurface(im, isovalue=0.2, rotation=110)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,10 @@ using Test
   im2 = ellipsoidPhantom(N; rng=StableRNG(1))
   @test im ≈ im2
 
-  im = ellipsoidPhantom(N; allowOcclusion=true)
+  im = ellipsoidPhantom((20,20); allowOcclusion=true)
   @test maximum(im) <= 1
+
+  @test_throws ArgumentError ellipsoidPhantom((20,20,20,20))
 
   #isosurface(im, isovalue=0.2, rotation=110)
 end


### PR DESCRIPTION
### Notable changes:
* add support for 2D
* extend Interface to include the following options
  * select minimum radius of generated ellipsoids `minRadius`
  * select minimum ellipsoid value `minValue`
  * choose whether ellipsoids should be added together (`allowOcclusion=false`) or if larger valued one should occlude another one (`allowOcclusion=true`)

### Other changes:
* changed `@info` statement to more suitable `@debug`
* remove shift being limited by radius