### PR TITLE
Modify vessel generator

### DIFF
--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -1,9 +1,76 @@
 # This file is originally based on Matlab code written by Christine Droigk
+"""
+  appendRoute!(route, stepsize, angle_xy, angle_xz)
+
+Append a new point to the route of the vessel.
+"""
+function appendRoute!(route, stepsize, angle_xy, angle_xz)
+    push!(route, route[end] .+ stepsize .* (cos(angle_xy)*cos(angle_xz), 
+                                            sin(angle_xy)*cos(angle_xz), 
+                                            sin(angle_xz)))
+end
 
 """
-vesselPath(N::NTuple{3,Int}; start, angle_xy, angle_xz, diameter, split_prob, change_prob, 
-  max_change, splitnr, max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, 
-  change_prob_increase, rng)
+  changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, max_change, rng)
+
+Simulate if and how the vessel changes its direction.
+"""
+function changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, max_change, rng)
+  if (rand(rng, Float64) < change_prob) && (length(route) > 2)# if directional change of the vessel
+    # randomly select new angles
+    change_angle_xy = pi*(max_change-2*max_change*rand(rng,Float64))
+    change_angle_xz = pi*(max_change-2*max_change*rand(rng,Float64))
+    # create range such that change is gradually applied
+    step_angle_xy = range(0, change_angle_xy, length=20)
+    step_angle_xz = range(0, change_angle_xz, length=20)
+    
+    for i = 1:max(length(step_angle_xy),length(step_angle_xz)) # until the largest change of the two angles is reached
+      if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
+        if i<=length(step_angle_xy) &&  i<=length(step_angle_xz) # both angles are still changing
+          appendRoute!(route, stepsize, angle_xy + step_angle_xy[i], angle_xz + step_angle_xz[i])
+        elseif i>length(step_angle_xy) &&  i<=length(step_angle_xz) # only xz-angle changes
+          appendRoute!(route, stepsize, angle_xy + change_angle_xy, angle_xz + step_angle_xz[i])
+        elseif i<=length(step_angle_xy) &&  i>length(step_angle_xz) # only xy-angle changes
+          appendRoute!(route, stepsize, angle_xy + step_angle_xy[i], angle_xz + change_angle_xz)
+        end
+      end
+    end
+    # set current angles to new angles
+    angle_xy = angle_xy + change_angle_xy
+    angle_xz = angle_xz + change_angle_xz
+  else
+      # if no directional change
+      num_step = 15
+      for _=1:num_step
+        appendRoute!(route, stepsize, angle_xy, angle_xz)
+      end
+  end
+  return angle_xy, angle_xz
+end
+
+"""
+  getDiameterRoute(route, diameter, change_diameter_splitting, splitnr)
+
+Compute the diameter anlong the route of the vessel.
+"""
+function getDiameterRoute(route, diameter, change_diameter_splitting, splitnr)
+  if splitnr>1
+    # for the case that the vessel leaves the image during a split the change is set to 1
+    # otherwise `range` throws an error since start and end do not match but length is 1
+    change_diameter_splitting_ = length(route) > 1 ? change_diameter_splitting : 1
+    # gradually change diameter from old value to current one
+    diameter_route = collect(range((1/change_diameter_splitting_)*diameter, diameter, length=length(route)))
+  else
+    # no change if vessel did not already split once
+    diameter_route = diameter*ones(length(route))
+  end
+  return diameter_route
+end
+
+"""
+  vesselPath(N::NTuple{3,Int}; start, angle_xy, angle_xz, diameter, split_prob, change_prob, 
+    max_change, splitnr, max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, 
+    change_prob_increase, rng)
 
 ### Input parameters:
 * N: Image size, given as a 3 tuple
@@ -48,92 +115,44 @@ function vesselPath(N::NTuple{3,Int};
   push!(route, start)
   while all( 1 .<= route[end] .< N) # while the route of the vessel is inside the image area
     
-    if (rand(rng, Float64) < change_prob) && (length(route) > 2)# if directional change of the vessel
-        change_angle_xy = pi*(max_change-2*max_change*rand(rng,Float64)) # throw dice for the angles of directional change. For more or less variations replace (0.1-0.2*rand)
-        change_angle_xz = pi*(max_change-2*max_change*rand(rng,Float64)) # same for other angle
-        step_angle_xy = range(0, change_angle_xy, length=20) # to obtain a piecewise change of angle
-        step_angle_xz = range(0, change_angle_xz, length=20)
-        
-        for i = 1:max(length(step_angle_xy),length(step_angle_xz)) # until the largest change of the two angles is reached
-          if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
-            if i<=length(step_angle_xy) &&  i<=length(step_angle_xz) # both angles are still changing
-              push!(route, route[end] .+ 
-                    stepsize .* (cos(angle_xy + step_angle_xy[i])*cos(angle_xz + step_angle_xz[i]), 
-                                 sin(angle_xy + step_angle_xy[i])*cos(angle_xz + step_angle_xz[i]), 
-                                 sin(angle_xz + step_angle_xz[i])) )
-            elseif i>length(step_angle_xy) &&  i<=length(step_angle_xz) # only xz-angle changes
-              push!(route, route[end] .+ 
-                    stepsize .* (cos(angle_xy + change_angle_xy)*cos(angle_xz + step_angle_xz[i]), 
-                                 sin(angle_xy + change_angle_xy)*cos(angle_xz + step_angle_xz[i]), 
-                                 sin(angle_xz + step_angle_xz[i])) )
-            elseif i<=length(step_angle_xy) &&  i>length(step_angle_xz) # only xy-angle changes
-              push!(route, route[end] .+ 
-                    stepsize .* (cos(angle_xy+step_angle_xy[i])*cos(angle_xz + change_angle_xz), 
-                                 sin(angle_xy+step_angle_xy[i])*cos(angle_xz + change_angle_xz), 
-                                 sin(angle_xz + change_angle_xz)) )
-            end
-          end
-        end
-        # set current angles to new angles
-        angle_xy = angle_xy + change_angle_xy # set current angles to new angles
-        angle_xz = angle_xz + change_angle_xz
-    else
-        # if no directional change
-        num_step = 15
-        for _=1:num_step
-          push!(route, route[end] .+ stepsize .* (cos(angle_xy)*cos(angle_xz), 
-                                                sin(angle_xy)*cos(angle_xz), 
-                                                sin(angle_xz))) # use old angle
-        end
-    end
+    angle_xy, angle_xz =  changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, max_change, rng)
     
+    # Splitting part
     if rand(rng, Float64) < split_prob && (length(route) > 3) && (splitnr ≤ max_number_splits) # if vessel is splitting
         min_angle_diff = 0.15*pi
-        angle_diff = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff # throw dice for angle between the resulting two vessel parts
-        angle_diff_z = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff # same for z-angle 
-      
-        part_a = rand(rng, Float64) # Part of the angle related to the first division
-        part_a_z = rand(rng, Float64) # Same for z-angle
+        # Randomly select the angle between the resulting two vessel parts
+        angle_diff_xy = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff
+        angle_diff_xz = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff
+        # Randomly select the part of the angle related to the first division
+        part_a_xy = rand(rng, Float64)
+        part_a_xz = rand(rng, Float64)
         
         # Call recursively this function for each of the two vessel
         # segments with adjusted angles and diameter. Here, an adjustment
         # of the splitting probabilities and directional change
         # probabilities is made.
-        routeA, diameterA = vesselPath(N; start=route[end], angle_xy=angle_xy-part_a*angle_diff, 
-            angle_xz=angle_xz-part_a_z*angle_diff_z, diameter=diameter*change_diameter_splitting,
+        routeA, diameterA = vesselPath(N; start=route[end], angle_xy=angle_xy-part_a_xy*angle_diff_xy, 
+            angle_xz=angle_xz-part_a_xz*angle_diff_xz, diameter=diameter*change_diameter_splitting,
             split_prob=split_prob*split_prob_factor, change_prob=change_prob+change_prob_increase, max_change, splitnr=splitnr+1, 
             max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, change_prob_increase, rng)
-        routeB, diameterB = vesselPath(N; start=route[end], angle_xy=angle_xy+(1-part_a)*angle_diff,  
-            angle_xz=angle_xy+(1-part_a_z)*angle_diff_z, diameter=diameter*change_diameter_splitting, 
+        routeB, diameterB = vesselPath(N; start=route[end], angle_xy=angle_xy+(1-part_a_xy)*angle_diff_xy,  
+            angle_xz=angle_xy+(1-part_a_xz)*angle_diff_xz, diameter=diameter*change_diameter_splitting, 
             split_prob=split_prob*split_prob_factor, change_prob=change_prob+change_prob_increase, max_change, splitnr=splitnr+1, 
             max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, change_prob_increase, rng)     
         
-        if splitnr>1
-          # set diameter for the splitting parts
-          change_diameter_splitting_ = length(route) > 1 ? change_diameter_splitting : 1
-          diameter_route = collect(range((1/change_diameter_splitting_)*diameter, diameter, length=length(route)))
-        else
-          diameter_route = diameter*ones(length(route))
-        end
+        diameter_route = getDiameterRoute(route, diameter, change_diameter_splitting, splitnr)
         append!(route, routeA, routeB)
         append!(diameter_route, diameterA, diameterB)
         return route, diameter_route
     end
   end
-
-  if splitnr>1
-    change_diameter_splitting_ = length(route) > 1 ? change_diameter_splitting : 1
-    diameter_route = collect(range((1/change_diameter_splitting_)*diameter, diameter, length=length(route)))
-  else
-    diameter_route = diameter*ones(length(route))
-  end
-
+  diameter_route = getDiameterRoute(route, diameter, change_diameter_splitting, splitnr)
   return route, diameter_route
 end
 
 
 """
-vesselPhantom(N::NTuple{3,Int}; oversampling=2, kargs...)
+  vesselPhantom(N::NTuple{3,Int}; oversampling=2, kargs...)
 
 ### Input parameters:
 * N: Image size, given as a 3 tuple

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -5,7 +5,7 @@ vesselPath(N::NTuple{3,Int}; start, angle_xy, angle_xz, diameter, split_prob, ch
   max_change, splitnr, max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, 
   change_prob_increase, rng)
 
-Input parameters:
+### Input parameters:
 * N: Image size, given as a 3 tuple
 * start: starting point given as a 3x1 vector
 * angle_xy: angle in radians describing the starting angle with which the
@@ -135,16 +135,27 @@ end
 """
 vesselPhantom(N::NTuple{3,Int}; oversampling=2, kargs...)
 
-Example usage:
+### Input parameters:
+* N: Image size, given as a 3 tuple
+* oversampling: Oversampling factor for the phantom. Default is 2.
+* rng: Random number generator
+* kernelWidth: Width (standard deviation) of the Gaussian kernel (in pixel) used for smoothing the phantom. If nothing is given, a random value is chosen.
+* kargs...: remaining keyword arguments for `vesselPath`
 
-  using GR, TrainingPhantoms, StableRNGs
-  im = vesselPhantom((40,40,40); start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
-                                diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
-                                rng = StableRNG(1));
-  isosurface(im, isovalue=0.2, rotation=110, tilt=40)
+### Example usage:
 
+  using GLMakie, TrainingPhantoms, StableRNGs
+
+  im = vesselPhantom((51,51,51); 
+          start=(1, 25, 25), angle_xy=0.0, angle_xz=0.0, 
+          diameter=2.5, split_prob=0.4, change_prob=0.3, 
+          max_change=0.3, splitnr=1, max_number_splits=1, rng StableRNG(123));
+
+  f = Figure(size=(300,300))
+  ax = Axis3(f[1,1], aspect=:data)
+  volume!(ax, im, algorithm=:iso, isorange=0.13, isovalue=0.3, colormap=:viridis, colorrange=[0.0,0.2])
 """
-function vesselPhantom(N::NTuple{3,Int}; oversampling=2, rng = GLOBAL_RNG, kargs...)
+function vesselPhantom(N::NTuple{3,Int}; oversampling=2, rng = GLOBAL_RNG, kernelWidth=nothing, kargs...)
   route, diameter_route = vesselPath(N; rng, kargs...)
   # add small sphere for every entry in the route
   obs = [ sphere( Float32.(route[i]), Float32(diameter_route[i]), 1.0f0) for i=eachindex(route) ]

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -150,9 +150,11 @@ function vesselPhantom(N::NTuple{3,Int}; oversampling=2, rng = GLOBAL_RNG, kargs
   obs = [ sphere( Float32.(route[i]), Float32(diameter_route[i]), 1.0f0) for i=eachindex(route) ]
   ranges = ntuple(d-> 1:N[d], 3)
   img = phantom(ranges..., obs, oversampling)
-  # filter for smoothing, offset to ensure minimal filter width
-  filterWidth = (1.0-0.2)*rand(rng) + 0.2
-  kernelWidth = ntuple(_ -> filterWidth*N[1] / 20, 3)
+  if isnothing(kernelWidth)
+    # filter for smoothing, offset to ensure minimal filter width
+    filterWidth = (1.0-0.3)*rand(rng) + 0.3
+    kernelWidth = ntuple(_ -> filterWidth*N[1] / 20, 3)
+  end  
   img = imfilter(img, Kernel.gaussian(kernelWidth))
   img[img .> 1] .= 1
   return img

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -189,5 +189,6 @@ function vesselPhantom(N::NTuple{3,Int}; oversampling=2, rng = GLOBAL_RNG, kerne
   end  
   img = imfilter(img, Kernel.gaussian(kernelWidth))
   img[img .> 1] .= 1
+  img[img .< 0] .= 0
   return img
 end

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -25,7 +25,7 @@ function changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, m
     step_angle_xz = range(0, change_angle_xz, length=steps_each_change)
     
     for i = 1:steps_each_change
-      if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
+      if all( 1 .<= route[end] .<= N) # check whether image boundaries are reached
           appendRoute!(route, stepsize, angle_xy + step_angle_xy[i], angle_xz + step_angle_xz[i])
       end
     end
@@ -35,7 +35,7 @@ function changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, m
   else
       # if no directional change
       for _=1:steps_no_change
-        if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
+        if all( 1 .<= route[end] .<= N) # check whether image boundaries are reached
           appendRoute!(route, stepsize, angle_xy, angle_xz)          
         end
       end
@@ -112,7 +112,7 @@ function vesselPath(N::NTuple{3,Int};
 
   route = NTuple{3,Float64}[]
   push!(route, start)
-  while all( 1 .<= route[end] .< N) # while the route of the vessel is inside the image area
+  while all( 1 .<= route[end] .<= N) # while the route of the vessel is inside the image area
     
     angle_xy, angle_xz =  changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, 
         max_change, steps_each_change, steps_no_change, rng)

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -24,15 +24,9 @@ function changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, m
     step_angle_xy = range(0, change_angle_xy, length=steps_each_change)
     step_angle_xz = range(0, change_angle_xz, length=steps_each_change)
     
-    for i = 1:max(length(step_angle_xy),length(step_angle_xz)) # until the largest change of the two angles is reached
+    for i = 1:steps_each_change
       if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
-        if i<=length(step_angle_xy) &&  i<=length(step_angle_xz) # both angles are still changing
           appendRoute!(route, stepsize, angle_xy + step_angle_xy[i], angle_xz + step_angle_xz[i])
-        elseif i>length(step_angle_xy) &&  i<=length(step_angle_xz) # only xz-angle changes
-          appendRoute!(route, stepsize, angle_xy + change_angle_xy, angle_xz + step_angle_xz[i])
-        elseif i<=length(step_angle_xy) &&  i>length(step_angle_xz) # only xy-angle changes
-          appendRoute!(route, stepsize, angle_xy + step_angle_xy[i], angle_xz + change_angle_xz)
-        end
       end
     end
     # set current angles to new angles
@@ -41,9 +35,8 @@ function changeDirection!(route, N, stepsize, angle_xy, angle_xz, change_prob, m
   else
       # if no directional change
       for _=1:steps_no_change
-        appendRoute!(route, stepsize, angle_xy, angle_xz)
-        if !all( 1 .<= route[end] .< N)
-          break
+        if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
+          appendRoute!(route, stepsize, angle_xy, angle_xz)          
         end
       end
   end

--- a/src/Vessel.jl
+++ b/src/Vessel.jl
@@ -1,9 +1,12 @@
 # This file is originally based on Matlab code written by Christine Droigk
 
 """
-vesselPath(N::NTuple{3,Int}; start, angle_xy, angle_xz, diameter, split_prob, change_prob, max_change, splitnr)
+vesselPath(N::NTuple{3,Int}; start, angle_xy, angle_xz, diameter, split_prob, change_prob, 
+  max_change, splitnr, max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, 
+  change_prob_increase, rng)
 
 Input parameters:
+* N: Image size, given as a 3 tuple
 * start: starting point given as a 3x1 vector
 * angle_xy: angle in radians describing the starting angle with which the
 * vessel runs. 
@@ -13,7 +16,12 @@ Input parameters:
 * change_prob: probability for directional change of the vessel route. Values between 0 and 1.
 * max_change: max_change * pi specifies the maximum direction-change angle.
 * splitnr: used for recursive call of the function. For the first call set it to 1. 
-* N: Image size, given as a 3x1 vector
+* max_number_splits: maximum number of splits of the vessel.
+* stepsize: stepsize of the vessel.
+* change_diameter_splitting: Indicates by how much the diameter decreases when the vessel splits
+* split_prob_factor: Factor by which the split probability `split_prob` is multiplied when the vessel splits
+* change_prob_increase: Increase of the change probability `change_prob` when the vessel splits
+* rng: Random number generator
  
 Output:
 * route: A length N vector containing the points 3D of the route of the vessel. The
@@ -29,21 +37,22 @@ function vesselPath(N::NTuple{3,Int};
                              change_prob, 
                              max_change, 
                              splitnr,
+                             max_number_splits = Inf,
+                             stepsize = max(N...)/200,
+                             change_diameter_splitting = 0.6,
+                             split_prob_factor = 0.5,
+                             change_prob_increase = 0.01,
                              rng::AbstractRNG = GLOBAL_RNG)
 
-  stepsize = 0.25
-  change_diameter_splitting = 4/5 # Indicates by how much the diameter decreases when the vessel is divided
   route = NTuple{3,Float64}[]
   push!(route, start)
-
-  counter = 1;
   while all( 1 .<= route[end] .< N) # while the route of the vessel is inside the image area
     
-    if rand(rng, Float64) < change_prob # if directional change of the vessel
+    if (rand(rng, Float64) < change_prob) && (length(route) > 2)# if directional change of the vessel
         change_angle_xy = pi*(max_change-2*max_change*rand(rng,Float64)) # throw dice for the angles of directional change. For more or less variations replace (0.1-0.2*rand)
         change_angle_xz = pi*(max_change-2*max_change*rand(rng,Float64)) # same for other angle
-        step_angle_xy = 0:(sign(change_angle_xy)*0.1*stepsize):change_angle_xy # to obtain a piecewise change of angle
-        step_angle_xz = 0:(sign(change_angle_xz)*0.1*stepsize):change_angle_xz
+        step_angle_xy = range(0, change_angle_xy, length=20) # to obtain a piecewise change of angle
+        step_angle_xz = range(0, change_angle_xz, length=20)
         
         for i = 1:max(length(step_angle_xy),length(step_angle_xz)) # until the largest change of the two angles is reached
           if all( 1 .<= route[end] .< N) # check whether image boundaries are reached
@@ -70,15 +79,18 @@ function vesselPath(N::NTuple{3,Int};
         angle_xz = angle_xz + change_angle_xz
     else
         # if no directional change
-        push!(route, route[end] .+ stepsize .* (cos(angle_xy)*cos(angle_xz), 
+        num_step = 15
+        for _=1:num_step
+          push!(route, route[end] .+ stepsize .* (cos(angle_xy)*cos(angle_xz), 
                                                 sin(angle_xy)*cos(angle_xz), 
                                                 sin(angle_xz))) # use old angle
+        end
     end
     
-    
-    if rand(rng, Float64) < split_prob && counter > 5 # if vessel is splitting
-        angle_diff = rand(rng, Float64)*pi/2 # throw dice for angle between the resulting two vessel parts
-        angle_diff_z = rand(rng, Float64)*pi/2 # same for z-angle 
+    if rand(rng, Float64) < split_prob && (length(route) > 3) && (splitnr ≤ max_number_splits) # if vessel is splitting
+        min_angle_diff = 0.15*pi
+        angle_diff = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff # throw dice for angle between the resulting two vessel parts
+        angle_diff_z = rand(rng, Float64)*(pi/2 - min_angle_diff) + min_angle_diff # same for z-angle 
       
         part_a = rand(rng, Float64) # Part of the angle related to the first division
         part_a_z = rand(rng, Float64) # Same for z-angle
@@ -89,10 +101,12 @@ function vesselPath(N::NTuple{3,Int};
         # probabilities is made.
         routeA, diameterA = vesselPath(N; start=route[end], angle_xy=angle_xy-part_a*angle_diff, 
             angle_xz=angle_xz-part_a_z*angle_diff_z, diameter=diameter*change_diameter_splitting,
-            split_prob=split_prob/2, change_prob=change_prob+0.01, max_change, splitnr=splitnr+1, rng)
+            split_prob=split_prob*split_prob_factor, change_prob=change_prob+change_prob_increase, max_change, splitnr=splitnr+1, 
+            max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, change_prob_increase, rng)
         routeB, diameterB = vesselPath(N; start=route[end], angle_xy=angle_xy+(1-part_a)*angle_diff,  
             angle_xz=angle_xy+(1-part_a_z)*angle_diff_z, diameter=diameter*change_diameter_splitting, 
-            split_prob=split_prob/2, change_prob=change_prob+0.01, max_change, splitnr=splitnr+1, rng)     
+            split_prob=split_prob*split_prob_factor, change_prob=change_prob+change_prob_increase, max_change, splitnr=splitnr+1, 
+            max_number_splits, stepsize, change_diameter_splitting, split_prob_factor, change_prob_increase, rng)     
         
         if splitnr>1
           # set diameter for the splitting parts
@@ -105,8 +119,6 @@ function vesselPath(N::NTuple{3,Int};
         append!(diameter_route, diameterA, diameterB)
         return route, diameter_route
     end
-    
-    counter = counter+1
   end
 
   if splitnr>1
@@ -132,15 +144,16 @@ Example usage:
   isosurface(im, isovalue=0.2, rotation=110, tilt=40)
 
 """
-function vesselPhantom(N::NTuple{3,Int}; oversampling=2, kargs...)
-  Q = zeros(N);
-
-  route, diameter_route = vesselPath(N; kargs...)
-
-  obs = [ ellipsoid( Float32.(route[i]), Float32.(ntuple(_->diameter_route[i],3)), 
-                              (0,0,0), 1.0f0) for i=1:length(route) ]
+function vesselPhantom(N::NTuple{3,Int}; oversampling=2, rng = GLOBAL_RNG, kargs...)
+  route, diameter_route = vesselPath(N; rng, kargs...)
+  # add small sphere for every entry in the route
+  obs = [ sphere( Float32.(route[i]), Float32(diameter_route[i]), 1.0f0) for i=eachindex(route) ]
   ranges = ntuple(d-> 1:N[d], 3)
   img = phantom(ranges..., obs, oversampling)
+  # filter for smoothing, offset to ensure minimal filter width
+  filterWidth = (1.0-0.2)*rand(rng) + 0.2
+  kernelWidth = ntuple(_ -> filterWidth*N[1] / 20, 3)
+  img = imfilter(img, Kernel.gaussian(kernelWidth))
   img[img .> 1] .= 1
   return img
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ using Test
   @testset "vesselPath Tests" begin
     rng = StableRNG(1)
     @testset "Normal operation" begin
-        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,20,20), angle_xy=0.0, angle_xz=0.0, diameter=2, 
+        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,20,20), angles=(0.0,0.0), diameter=2, 
                                            split_prob=0.5, change_prob=0.5, max_change=0.2, 
                                            splitnr=1, max_number_splits=2, stepsize=0.25, 
                                            change_diameter_splitting=4/5, split_prob_factor=0.5, 
@@ -36,7 +36,7 @@ using Test
         @test length(route) == length(diameter_route)
     end
     @testset "Start outside volume" begin
-        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,50,20), angle_xy=0.0, angle_xz=0.0, diameter=2, 
+        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,50,20), angles=(0.0,0.0), diameter=2, 
                                            split_prob=0.5, change_prob=0.5, max_change=0.2, 
                                            splitnr=1, max_number_splits=2, stepsize=0.25, 
                                            change_diameter_splitting=4/5, split_prob_factor=0.5, 
@@ -46,17 +46,25 @@ using Test
     end
   end
   @testset "vesselPhantom" begin
-    im = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
+    im = vesselPhantom(N; start=(1, 20, 20), angles = (0.0, 0.0),
                        diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
                        rng = StableRNG(1));
 
-    im2 = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
+    im2 = vesselPhantom(N; start=(1, 20, 20), angles = (0.0, 0.0), 
                         diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
                         rng = StableRNG(1));
     @test im ≈ im2
     @test size(im) == N
     @test maximum(im) == 1.0
     @test minimum(im) == 0.0
+
+    im = vesselPhantom((40,40); start=(1, 20), angles = (0.0,), 
+                       diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
+                       rng = StableRNG(1));
+    @test size(im) == (40,40)
+
+    @test_throws ArgumentError vesselPhantom((20,20,20,20))
+
   end
 
   @testset "Ellipsoid" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,21 +4,67 @@ using Test
 
 @testset "TrainingPhantoms.jl" begin
   N = (40,40,40)
+  @testset "Vessel" begin    
+    @testset "getDiameterRoute" begin
+      route = [1, 2, 3, 4, 5]
+      diameter = 2.0
+      change_diameter_splitting = 0.5
+      splitnr = 2
+  
+      @testset "Normal operation" begin
+          result = TrainingPhantoms.getDiameterRoute(route, diameter, change_diameter_splitting, splitnr)
+          @test length(result) == length(route)
+          @test result[1] == (1/change_diameter_splitting)*diameter
+          @test result[end] == diameter
+      end
+  
+      @testset "No split" begin
+          result = TrainingPhantoms.getDiameterRoute(route, diameter, change_diameter_splitting, 1)
+          @test all(result .== diameter)
+      end
+    end
+  end
 
-  # Vessel Phantom
-  im = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
-                                diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
-                                rng = StableRNG(1));
+  @testset "vesselPath Tests" begin
+    rng = StableRNG(1)
+    @testset "Normal operation" begin
+        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,20,20), angle_xy=0.0, angle_xz=0.0, diameter=2, 
+                                           split_prob=0.5, change_prob=0.5, max_change=0.2, 
+                                           splitnr=1, max_number_splits=2, stepsize=0.25, 
+                                           change_diameter_splitting=4/5, split_prob_factor=0.5, 
+                                           change_prob_increase=0.01, rng=rng)
+        @test length(route) == length(diameter_route)
+    end
+    @testset "Start outside volume" begin
+        route, diameter_route = TrainingPhantoms.vesselPath(N; start=(1,50,20), angle_xy=0.0, angle_xz=0.0, diameter=2, 
+                                           split_prob=0.5, change_prob=0.5, max_change=0.2, 
+                                           splitnr=1, max_number_splits=2, stepsize=0.25, 
+                                           change_diameter_splitting=4/5, split_prob_factor=0.5, 
+                                           change_prob_increase=0.01, rng=rng)
+        @test length(route) == 1
+        @test length(diameter_route) == 1
+    end
+  end
+  @testset "vesselPhantom" begin
+    im = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
+                       diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
+                       rng = StableRNG(1));
 
-  im2 = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
-                                diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
-                                rng = StableRNG(1));
-  @test im ≈ im2
+    im2 = vesselPhantom(N; start=(1, 20, 20), angle_xy=0.0, angle_xz=0.0, 
+                        diameter=2, split_prob=0.5, change_prob=0.5, max_change=0.2, splitnr=1,
+                        rng = StableRNG(1));
+    @test im ≈ im2
+    @test size(im) == N
+    @test maximum(im) == 1.0
+    @test minimum(im) == 0.0
+  end
 
-   # Ellipsoid Phantom
-  im = ellipsoidPhantom(N; rng=StableRNG(1))
-  im2 = ellipsoidPhantom(N; rng=StableRNG(1))
-  @test im ≈ im2
 
-  #isosurface(im, isovalue=0.2, rotation=110)
+  @testset "Ellipsoid" begin
+    # Ellipsoid Phantom
+    im = ellipsoidPhantom(N; rng=StableRNG(1))
+    im2 = ellipsoidPhantom(N; rng=StableRNG(1))
+    @test im ≈ im2
+    @test size(im) == N
+  end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,5 +65,10 @@ using Test
     im2 = ellipsoidPhantom(N; rng=StableRNG(1))
     @test im ≈ im2
     @test size(im) == N
+
+    im = ellipsoidPhantom((20,20); allowOcclusion=true)
+    @test maximum(im) <= 1
+
+    @test_throws ArgumentError ellipsoidPhantom((20,20,20,20))
   end
 end


### PR DESCRIPTION
The vessel phantom generator has been modified to make it much easier to find parameters for good-looking phantoms.

### Notable changes
* add keyword arguments for parameters that were previously inaccessible
* the generated route of vessels is now independent of the size of the volume
* introduce minimum splitting angle to reduce vessel overlap after splitting
* add parameter `max_number_splits` to limit the number of splits
* separate function body of `vesselPath` into different functions
* smooth final phantom
* add 2D support